### PR TITLE
fixed custom_exit

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -29,26 +29,23 @@ short int custom_cd(char **envp, char **args)
 
 short int custom_exit(char **args)
 {
-    int status;
-    int num_len;
+    long long value;
 
-    status = 0;
-    if (!args || !args[0])
-    {
-        printf("exit\n");
-        exit(status);
-    }
-    num_len = ft_is_str_num(args[0]);
-    if (num_len == 0 || num_len > 3) {
-        printf("exit: %s: numeric argument required\n", args[0]);
-        exit(255);
-    }
-    status = ft_atoi(args[0]);
-    if (status < 0 || status > 255) {
-        printf("exit\n");
-        exit(255);
-    }
     printf("exit\n");
-    exit(status);
-    return 0;
+
+    if (!args || !args[1])
+        exit(0);
+
+    if (!ft_atoany(args[1], &value))
+    {
+        printf("exit: %s: numeric argument required\n", args[1]);
+        exit(255);
+    }
+    if (args[2])
+    {
+        printf("exit: too many arguments\n");
+        return (1);
+    }
+    exit((unsigned char)(value % 256));
 }
+

--- a/src/libft/Makefile
+++ b/src/libft/Makefile
@@ -60,6 +60,7 @@ SRCS = \
 	ft_lstiter_bonus.c \
 	ft_lstmap_bonus.c \
 	ft_strtok.c \
+	ft_atoany.c \
 	ft_is_str_num.c
 
 OBJS = $(SRCS:.c=.o)

--- a/src/libft/ft_atoany.c
+++ b/src/libft/ft_atoany.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_atoi.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dimendon <dimendon@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/11/11 16:55:01 by dimendon          #+#    #+#             */
+/*   Updated: 2025/06/04 20:26:55 by dimendon         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+#include <ctype.h>
+#include <limits.h>
+
+int checkoverflow(const char *str, int *i, int sign, long long *result)
+{
+    long long res;
+    int digit;
+
+    res = *result;
+    while (str[*i] >= '0' && str[*i] <= '9')
+	{
+        digit = str[*i] - '0';
+        if (sign == 1) {
+            if (res > (LLONG_MAX - digit) / 10)
+                return (0);
+        } else {
+            if ((unsigned long long)res > ((unsigned long long)(-(LLONG_MIN + digit))) / 10)
+                return (0);
+        }
+        res = res * 10 + digit;
+        (*i)++;
+    }
+    *result = res;
+    return (1);
+}
+
+int ft_atoany(const char *str, long long *out)
+{
+    long long result;
+    int sign;
+    int i;
+
+    result = 0;
+    sign = 1;
+    i = 0;
+    while (str[i] == ' ' || (str[i] >= 9 && str[i] <= 13))
+        i++;
+    if (str[i] == '+' || str[i] == '-')
+    {
+        if (str[i] == '-')
+            sign = -1;
+        i++;
+    }
+    if (str[i] < '0' || str[i] > '9')
+        return 0;
+    if (!checkoverflow(str, &i, sign, &result))
+        return 0;
+    *out = result * sign;
+    return (1);
+}
+
+

--- a/src/libft/libft.h
+++ b/src/libft/libft.h
@@ -68,5 +68,6 @@ void	ft_lstiter(t_list *lst, void (*f)(void *));
 t_list	*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
 char	*ft_strtok(char *str, const char delim);
 int		ft_is_str_num(const char *str);
+int		ft_atoany(const char *str, long long *out);
 
 #endif


### PR DESCRIPTION
Now properly uses module of big numbers. Also added ft_atoany  to libft to handle this case and any other conversion